### PR TITLE
Offer update if assets manifest doesn't exist on Flipper

### DIFF
--- a/Flipper/Packages/UI/Sources/Device/Components/Update/DeviceUpdateCardModel.swift
+++ b/Flipper/Packages/UI/Sources/Device/Components/Update/DeviceUpdateCardModel.swift
@@ -99,14 +99,24 @@ class DeviceUpdateCardModel: ObservableObject {
     func onFlipperChanged(_ oldValue: Flipper?) {
         updateState()
 
-        guard flipper?.state == .connected else { return }
+        guard flipper?.state == .connected else {
+            resetState()
+            return
+        }
 
-        if flipper?.state == .connected { verifyManifest() }
+        if oldValue?.state != .connected {
+            verifyManifest()
+        }
 
         verifyUpdateResult()
     }
+    
+    func resetState() {
+        hasManifest = .idle
+    }
 
     func verifyManifest() {
+        guard case .idle = hasManifest else { return }
         hasManifest = .working
         Task {
             do {


### PR DESCRIPTION
### Background

qFlipper offer update if assets not exist
We now we can also

### Changes

Request size manifest file

### Test plan

Try delete manifest file and reopen application