### PR TITLE
fix(Urls): helpToKnowName and helpToTurnOnBluetooth Urls

### DIFF
--- a/Flipper/Packages/UI/Sources/Common/URLs.swift
+++ b/Flipper/Packages/UI/Sources/Common/URLs.swift
@@ -33,7 +33,7 @@ extension URL {
     // MARK: Help
 
     static var helpToKnowName: URL {
-        .init(string: "https://docs.flipperzero.one/basics/settings#eJsLP")!
+        .init(string: "https://docs.flipperzero.one/basics/settings#rRnAy")!
     }
 
     static var helpToTurnOnBluetooth: URL {

--- a/Flipper/Packages/UI/Sources/Common/URLs.swift
+++ b/Flipper/Packages/UI/Sources/Common/URLs.swift
@@ -33,11 +33,11 @@ extension URL {
     // MARK: Help
 
     static var helpToKnowName: URL {
-        .init(string: "https://docs.flipperzero.one/basics/control/dolphin#yj-flipper-name")!
+        .init(string: "https://docs.flipperzero.one/basics/settings#eJsLP")!
     }
 
     static var helpToTurnOnBluetooth: URL {
-        .init(string: "https://docs.flipperzero.one/basics/control/bluetooth#n3-turn-on-bluetooth")!
+        .init(string: "https://docs.flipperzero.one/basics/settings#eJsLP")!
     }
 
     static var helpToInstallFirmware: URL {


### PR DESCRIPTION
Hi! 

I was playing around with the App while my flipper is not here and noticed that this two urls needed to be updated.

![image](https://user-images.githubusercontent.com/23619646/184781327-b62e4ad2-223c-421d-9c20-9670502994e7.png)
