### PR TITLE
Feature proposal: Importing files

### DIFF
--- a/Flipper/Flipper.xcodeproj/project.pbxproj
+++ b/Flipper/Flipper.xcodeproj/project.pbxproj
@@ -457,7 +457,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flipperdevices.main.KeyPreview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -485,7 +485,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flipperdevices.main.KeyPreview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -633,7 +633,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flipperdevices.main;
 				PRODUCT_NAME = Flipper;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -662,7 +662,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.2;
+				MARKETING_VERSION = 1.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flipperdevices.main;
 				PRODUCT_NAME = Flipper;
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerView.swift
+++ b/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerView.swift
@@ -1,6 +1,7 @@
 import Core
 import SwiftUI
 import Peripheral
+import UniformTypeIdentifiers
 
 struct FileManagerView: View {
     @StateObject var viewModel: FileManagerViewModel
@@ -47,7 +48,7 @@ struct FileManagerView: View {
         }
         .fileImporter(
             isPresented: $viewModel.isFilePickerDisplayed,
-            allowedContentTypes: viewModel.allowedContentTypes
+            allowedContentTypes: [UTType.item]
         ) { result in viewModel.importFile(url: try? result.get()) }
         .onAppear {
             viewModel.update()

--- a/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerView.swift
+++ b/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerView.swift
@@ -36,7 +36,19 @@ struct FileManagerView: View {
                     }
 
                     Button {
-                        viewModel.isFilePickerDisplayed = true
+                        /*
+                            File picker won't be shown if hidden by a swipe down
+                            instead of the Cancel button, so we use this workaround.
+                            Apple knows about this but so hopefully it'll be fixed soon.
+                         */
+                        if viewModel.isFilePickerDisplayed {
+                            viewModel.isFilePickerDisplayed = false
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                                viewModel.isFilePickerDisplayed = true
+                            }
+                        } else {
+                            viewModel.isFilePickerDisplayed = true
+                        }
                     } label: {
                         Text("Import")
                     }

--- a/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerView.swift
+++ b/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerView.swift
@@ -36,19 +36,7 @@ struct FileManagerView: View {
                     }
 
                     Button {
-                        /*
-                            File picker won't be shown if hidden by a swipe down
-                            instead of the Cancel button, so we use this workaround.
-                            Apple knows about this but so hopefully it'll be fixed soon.
-                         */
-                        if viewModel.isFilePickerDisplayed {
-                            viewModel.isFilePickerDisplayed = false
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                                viewModel.isFilePickerDisplayed = true
-                            }
-                        } else {
-                            viewModel.isFilePickerDisplayed = true
-                        }
+                        viewModel.showFileImporter()
                     } label: {
                         Text("Import")
                     }
@@ -59,9 +47,13 @@ struct FileManagerView: View {
             }
         }
         .fileImporter(
-            isPresented: $viewModel.isFilePickerDisplayed,
+            isPresented: $viewModel.isFileImporterPresented,
             allowedContentTypes: [UTType.item]
-        ) { result in viewModel.importFile(url: try? result.get()) }
+        ) { result in
+            if case .success(let url) = result {
+                viewModel.importFile(url: url)
+            }
+        }
         .onAppear {
             viewModel.update()
         }

--- a/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerView.swift
+++ b/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerView.swift
@@ -33,12 +33,22 @@ struct FileManagerView: View {
                     } label: {
                         Text("Folder")
                     }
+
+                    Button {
+                        viewModel.isFilePickerDisplayed = true
+                    } label: {
+                        Text("Import")
+                    }
                 } label: {
                     Image(systemName: "plus")
                         .foregroundColor(.primary)
                 }
             }
         }
+        .fileImporter(
+            isPresented: $viewModel.isFilePickerDisplayed,
+            allowedContentTypes: viewModel.allowedContentTypes
+        ) { result in viewModel.importFile(url: try? result.get())}
         .onAppear {
             viewModel.update()
         }

--- a/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerView.swift
+++ b/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerView.swift
@@ -48,7 +48,7 @@ struct FileManagerView: View {
         .fileImporter(
             isPresented: $viewModel.isFilePickerDisplayed,
             allowedContentTypes: viewModel.allowedContentTypes
-        ) { result in viewModel.importFile(url: try? result.get())}
+        ) { result in viewModel.importFile(url: try? result.get()) }
         .onAppear {
             viewModel.update()
         }

--- a/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerViewModel.swift
+++ b/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerViewModel.swift
@@ -25,7 +25,7 @@ class FileManagerViewModel: ObservableObject {
     }
     @Published var text: String = ""
     @Published var name: String = ""
-    @Published var isFilePickerDisplayed: Bool = false
+    @Published var isFilePickerDisplayed = false
 
     var supportedExtensions: [String] = [
         ".ibtn", ".nfc", ".shd", ".sub", ".rfid", ".ir", ".fmf", ".txt"
@@ -139,10 +139,10 @@ class FileManagerViewModel: ObservableObject {
                 let path = path.appending(name)
                 var bytes = [UInt8](repeating: 0, count: data.count)
                 data.copyBytes(to: &bytes, count: data.count)
-            
+
                 try await rpc.writeFile(at: path, bytes: bytes)
                 await listDirectory()
-            
+
                 do {
                     url.stopAccessingSecurityScopedResource()
                 }

--- a/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerViewModel.swift
+++ b/Flipper/Packages/UI/Sources/Options/FileManager/FileManagerViewModel.swift
@@ -4,7 +4,6 @@ import Analytics
 import Peripheral
 import Combine
 import Logging
-import UIKit
 import UniformTypeIdentifiers
 
 import struct Foundation.Date
@@ -30,9 +29,6 @@ class FileManagerViewModel: ObservableObject {
     var supportedExtensions: [String] = [
         ".ibtn", ".nfc", ".shd", ".sub", ".rfid", ".ir", ".fmf", ".txt"
     ]
-    var allowedContentTypes: [UTType] {
-        supportedExtensions.compactMap { UTType(filenameExtension: String($0.dropFirst(1)), conformingTo: .text) }
-    }
 
     enum Content {
         case list([Element])


### PR DESCRIPTION
### Background

A few days ago I downloaded a set of intercom keys on my iPhone and I wanted to transfer them to my Flipper somehow. I found out I can't do this via the iOS app, so I decided to implement the feature myself.

### How to use

1. Go to Options > File Manager
2. Choose a directory 
3. Tap the + menu and select Import

### Demo

https://user-images.githubusercontent.com/6809803/190249674-4b841765-9f03-40f4-bc3a-f2f9e0b687cd.mp4
