### PR TITLE
[Archive] Show items from subdirectories

### DIFF
--- a/Flipper/Packages/Core/Sources/Archive/Manifest/MobileManifest.swift
+++ b/Flipper/Packages/Core/Sources/Archive/Manifest/MobileManifest.swift
@@ -11,7 +11,10 @@ extension FileStorage {
         progress: (Double) -> Void
     ) async throws -> Manifest {
         let root = root.appending("any")
-        let paths = try await listAllFiles(at: root) { listingProgress in
+        let paths = try await listAllFiles(
+            recursively: true,
+            at: root
+        ) { listingProgress in
             progress(listingProgress / 2)
         }
 
@@ -27,42 +30,71 @@ extension FileStorage {
     }
 
     private func listAllFiles(
+        recursively: Bool = false,
         at root: Path,
         progress: (Double) -> Void
     ) async throws -> [Path] {
         var result: [Path] = .init()
-
         progress(0)
-
         for (index, type) in FileType.allCases.enumerated() {
             let path = root.appending(type.location)
-
-            let files = try await listFiles(at: path)
-                .filter { !$0.hasPrefix(".") }
-                .filter { $0.hasSuffix(type.extension) }
-                .map { path.appending($0) }
-
+            let files = try await listFiles(
+                at: path,
+                matching: type,
+                recursively: recursively
+            )
             result.append(contentsOf: files)
-
             progress(Double(index + 1) / Double(FileType.allCases.count))
         }
-
         return result
     }
 
-    private func listFiles(at path: Path) async throws -> [String] {
+    private func listFiles(
+        at path: Path,
+        matching fileType: FileType,
+        recursively: Bool = false
+    ) async throws -> [Path] {
+        var result: [Path] = .init()
+
+        let elements = try await listAsync(at: path)
+            .filter { !$0.hasPrefix(".") }
+            .map { path.appending($0) }
+
+        let files = elements.filter { path in
+            path.string.hasSuffix(fileType.extension)
+        }
+        result.append(contentsOf: files)
+
+        guard recursively else { return result }
+        for directory in elements.filter({ isValidDirectory($0)} ) {
+            let recursiveElements = try await listFiles(
+                at: directory,
+                matching: fileType,
+                recursively: recursively
+            )
+            result.append(contentsOf: recursiveElements)
+        }
+        return result
+    }
+
+    private func listAsync(at path: Path) async throws -> [String] {
         guard isExists(path) else {
             return []
         }
-        return try list(at: path).compactMap { child in
-            guard !isDirectory(.init(string: child)) else {
-                return nil
+        var result: [String] = .init()
+        let elements = try list(at: path)
+        for element in elements {
+            let path = Path(string: element)
+            guard !isDirectory(path) else {
+                result.append(contentsOf: try await listAsync(at: path))
+                return result
             }
-            return child
+            result.append(element)
         }
+        return result
     }
 
-    func getAllHashes(
+    private func getAllHashes(
         for paths: [Path],
         progress: (Double) -> Void
     ) async throws -> [Path: Hash] {
@@ -80,5 +112,13 @@ extension FileStorage {
 
     private func getFileHash(at path: Path) async throws -> Hash {
         try .init(read(path).md5)
+    }
+
+    private func isValidDirectory(_ path: Path) -> Bool {
+        guard
+            isDirectory(path),
+            let lastComponent = path.lastComponent
+        else { return false }
+        return lastComponent != String.ignoredDirectory
     }
 }

--- a/Flipper/Packages/Core/Sources/Constants.swift
+++ b/Flipper/Packages/Core/Sources/Constants.swift
@@ -4,6 +4,9 @@ extension String {
     static var appGroup: String {
         "group.com.flipperdevices.main"
     }
+    static var ignoredDirectory: String {
+        "assets"
+    }
 }
 
 extension URL {

--- a/Flipper/Packages/Peripheral/Sources/RPC/Model/Path.swift
+++ b/Flipper/Packages/Peripheral/Sources/RPC/Model/Path.swift
@@ -17,6 +17,14 @@ public struct Path: Equatable, Hashable {
         .init(components: components.dropLast())
     }
 
+    public var subdirectories: [String] {
+        var copy = self
+        guard copy.components.count > 3 else { return [] }
+        copy.components.removeFirst(2)
+        copy.components.removeLast()
+        return copy.components
+    }
+
     public init<T: StringProtocol>(string: T) {
         self.components = String(string).split(separator: "/").map(String.init)
     }

--- a/Flipper/Packages/UI/Sources/Archive/Components/CompactItem.swift
+++ b/Flipper/Packages/UI/Sources/Archive/Components/CompactItem.swift
@@ -14,13 +14,22 @@ struct CompactItem: View {
             }
 
             Spacer()
-            Text(item.name.value)
-                .lineLimit(1)
-                .font(.system(size: 14, weight: .medium))
-                .padding(.horizontal, 8)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(item.name.value)
+                    .lineLimit(1)
+                    .font(.system(size: 14, weight: .medium))
+                    .padding(.horizontal, 8)
+                if item.subdirectories.count > 0 {
+                    Text(item.subdirectories.joined(separator: "/")+"/")
+                        .foregroundColor(.black60)
+                        .lineLimit(1)
+                        .font(.system(size: 10, weight: .regular))
+                        .padding(.horizontal, 8)
+                }
+            }
             Spacer()
         }
-        .frame(height: 81)
+        .frame(height: 84)
         .background(Color.groupedBackground)
         .cornerRadius(10)
         .compositingGroup()


### PR DESCRIPTION
# What does this PR do
- [x] Show items from subdirectories for all supported File Types
- [x] Indicate which subdirectories an item belongs to in the `CompactItem` view.
- [ ] Indicate which subdirectories an item belongs to in the `CardView` view.
- [ ] Indicate which subdirectories an item belongs to in the `CategoryItem` view.
- [ ] Show subdirectories in `CategoryList`, so we can navigate through them.

# What does it look like (now)
![IMG_1117A8B8D88C-1](https://github.com/flipperdevices/Flipper-iOS-App/assets/1584586/c2198b20-4ce3-49fe-abbc-82d2968f4f04)
