### PR TITLE
Fix filenames containing dots (.)

### DIFF
--- a/Flipper/Packages/Core/Sources/Archive/Item/ArchiveItem+Name.swift
+++ b/Flipper/Packages/Core/Sources/Archive/Item/ArchiveItem+Name.swift
@@ -12,7 +12,10 @@ extension ArchiveItem {
 
 extension ArchiveItem.Name {
     init<T: StringProtocol>(filename: T) throws {
-        guard let name = filename.split(separator: ".").first else {
+        guard let name = filename
+            .split(separator: ".", omittingEmptySubsequences: false)
+            .dropLast()
+            .joined(separator: ".") else {
             throw ArchiveItem.Error.invalidName(String(filename))
         }
         self.value = String(name)


### PR DESCRIPTION
File name check used split().first, which would discard the rest of the file name if the file had dots in the actual name. This caused issues with those files, like not being able to emulate, or content not syncing properly.

Can't test if this resolves the issue since i have no way to compile the app, but this error in the code seems like exactly what the app is having issues with in practice.