### PR TITLE
[MFKey32] Fix padding

### DIFF
--- a/Flipper/Packages/Core/Sources/ReaderAttack/MFKey.swift
+++ b/Flipper/Packages/Core/Sources/ReaderAttack/MFKey.swift
@@ -39,8 +39,6 @@ public struct MFKey32: Hashable, Sendable {
 extension String {
     init<T: BinaryInteger>(paddingHexadecimal value: T) {
         let string = String(value, radix: 16)
-        self = string.count.isMultiple(of: 2)
-            ? string
-            : "0\(string)"
+        self = String(repeating: "0", count: max(0, 12 - string.count)) + string
     }
 }


### PR DESCRIPTION
Saved keys need leading 0s and a fixed length of 12 to work when reading card

fixes #180 