### PR TITLE
Fix App Shortcuts phrase missing applicationName placeholder

### DIFF
--- a/Flipper/AppIntents/FlipperShortcuts.swift
+++ b/Flipper/AppIntents/FlipperShortcuts.swift
@@ -18,7 +18,8 @@ struct FlipperShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: PlayAlert(),
             phrases: [
-                "Find Flipper"
+                "Find \(.applicationName)",
+                "Find my \(.applicationName)"
             ]
         )
     }


### PR DESCRIPTION
Siri Shortcut phrases must contain \(.applicationName); a hardcoded "Find Flipper" phrase fails App Shortcuts validation and breaks the build.