### PR TITLE
Group installed apps by category

### DIFF
--- a/Flipper/iOS/UI/Apps/Segments/InstalledAppsView.swift
+++ b/Flipper/iOS/UI/Apps/Segments/InstalledAppsView.swift
@@ -8,6 +8,15 @@ struct InstalledAppsView: View {
         model.installed
     }
 
+    var groupedApplications: [(category: String, apps: [Application])] {
+        Dictionary(grouping: applications, by: \.category.name)
+            .sorted {
+                let order = $0.key.localizedCaseInsensitiveCompare($1.key)
+                return order == .orderedAscending
+            }
+            .map { (category: $0.key, apps: $0.value) }
+    }
+
     var isLoading: Bool {
         model.installedStatus == .loading
     }
@@ -75,11 +84,37 @@ struct InstalledAppsView: View {
                             }
                             .padding(.horizontal, 14)
 
-                            AppList(
-                                applications: applications,
-                                isInstalled: true,
-                                showPlaceholder: isLoading
-                            )
+                            if groupedApplications.isEmpty {
+                                AppList(
+                                    applications: [],
+                                    isInstalled: true,
+                                    showPlaceholder: isLoading
+                                )
+                            } else {
+                                ForEach(
+                                    groupedApplications,
+                                    id: \.category
+                                ) { section in
+                                    let isLastSection = section.category ==
+                                        groupedApplications.last?.category
+
+                                    VStack(alignment: .leading, spacing: 12) {
+                                        Text(section.category)
+                                            .font(.system(
+                                                size: 14,
+                                                weight: .bold
+                                            ))
+                                            .padding(.horizontal, 14)
+
+                                        AppList(
+                                            applications: section.apps,
+                                            isInstalled: true,
+                                            showPlaceholder:
+                                                isLoading && isLastSection
+                                        )
+                                    }
+                                }
+                            }
                         }
                         .padding(.vertical, 14)
                         .opacity(noApps ? 0 : 1)


### PR DESCRIPTION
# Group installed apps by category

## Summary

- Group installed applications into category sections.
- Sort category sections alphabetically while preserving the existing app order
  within each section.
- Keep the loading placeholder visible only once during refresh.

## Motivation

The Installed tab currently displays every application in one flat list. This
becomes difficult to navigate when a device has many applications installed.
Application manifests already provide category information, so the UI can use
the existing data without changing the manifest format or catalog behavior.

## Testing

- `./swiftlint lint --config .swiftlint.yml iOS/UI/Apps/Segments/InstalledAppsView.swift`
- `xcodebuild -project Flipper/Flipper.xcodeproj -scheme "Flipper(iOS)" -destination "platform=iOS Simulator,id=FA554DFE-4BE7-414C-9D08-0E391AA03D40" -derivedDataPath /tmp/flipper-ios-derived-data CODE_SIGNING_ALLOWED=NO build`

Both checks pass.
